### PR TITLE
Fix (restore) search functionality to use restoredcdc.org instead of cdc.gov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/build_search_index.py
+++ b/build_search_index.py
@@ -1,0 +1,172 @@
+"""
+build_search_index.py
+---------------------
+Creates a Whoosh search index from the content in a LevelDB database.
+This script:
+  - Retrieves HTML entries from the 'cdc_database'
+  - Normalizes paths
+  - Parses out main text via BeautifulSoup
+  - Deduplicates multiple entries for the same normalized path
+  - Commits documents to the 'search_index' directory
+"""
+
+import os
+import plyvel
+import warnings
+from bs4 import BeautifulSoup, XMLParsedAsHTMLWarning, MarkupResemblesLocatorWarning
+from bs4.exceptions import ParserRejectedMarkup
+from whoosh.index import create_in
+from whoosh.fields import Schema, TEXT, ID
+from whoosh.analysis import StemmingAnalyzer
+from tqdm import tqdm  # progress bar library
+
+# import sys
+# Optional: increase recursion limit if needed
+# sys.setrecursionlimit(5000)
+
+# Suppress specific warnings from BeautifulSoup's parser
+warnings.filterwarnings("ignore", category=XMLParsedAsHTMLWarning)
+warnings.filterwarnings("ignore", category=MarkupResemblesLocatorWarning)
+
+
+def normalize_path(raw_path):
+    """
+    Normalize the URL path by:
+      - Converting to lowercase
+      - Removing any query string (anything after '?')
+      - Stripping trailing slashes (unless it's the root)
+      - Removing '/index.html' or '/index.htm' if present
+
+    Returns the normalized path as a string.
+    """
+    path = raw_path.lower()
+
+    # Remove query string if present
+    if "?" in path:
+        path = path.split("?", 1)[0]
+
+    # Remove trailing slash, except if path == "/"
+    if path != "/" and path.endswith("/"):
+        path = path.rstrip("/")
+
+    # Remove specific index pages
+    if path.endswith("/index.html"):
+        path = path[: -len("/index.html")]
+    elif path.endswith("/index.htm"):
+        path = path[: -len("/index.htm")]
+
+    return path
+
+
+# Define our Whoosh schema for indexing
+schema = Schema(
+    path=ID(unique=True, stored=True),
+    title=TEXT(stored=True),
+    # 'spelling=True' stores unmodified terms, helpful for suggestions
+    content=TEXT(stored=True, analyzer=StemmingAnalyzer(), spelling=True),
+)
+
+# Create or open the index directory
+if not os.path.exists("search_index"):
+    os.mkdir("search_index")
+
+ix = create_in("search_index", schema)
+writer = ix.writer()
+
+# Open the LevelDB database (converted .zim)
+db = plyvel.DB("./cdc_database")
+content_db = db.prefixed_db(b"c-")
+mimetype_db = db.prefixed_db(b"m-")
+
+processed = 0
+skipped = 0
+
+print("Counting total number of documents in DB for progress…")
+total_docs = sum(1 for _ in content_db)
+print(f"Total docs in DB: {total_docs}")
+
+# We'll track normalized paths to handle duplicates
+# e.g. dedup_dict[norm] = (raw_path, length_of_raw)
+dedup_dict = {}
+
+# Progress bar for clarity
+progress_bar = tqdm(
+    content_db, total=total_docs, unit="doc", desc="Indexing documents", mininterval=10
+)
+
+for key, value in progress_bar:
+    raw_path = key.decode("utf-8", errors="ignore")
+    norm = normalize_path(raw_path)
+
+    # Check mimetype; skip if not HTML
+    mime_val = mimetype_db.get(key)
+    if not mime_val:
+        skipped += 1
+        continue
+    mime_str = mime_val.decode("utf-8", errors="ignore").lower()
+    if not mime_str.startswith("text/html"):
+        skipped += 1
+        continue
+
+    # Decode the HTML content
+    html = value.decode("utf-8", errors="replace")
+
+    # Attempt to parse with BeautifulSoup
+    try:
+        soup = BeautifulSoup(html, "lxml")
+    except ParserRejectedMarkup:
+        tqdm.write(f"Parser rejected {raw_path}, skipping.")
+        skipped += 1
+        continue
+    except Exception as e:
+        tqdm.write(f"Skipping {raw_path} due to parse error: {e}")
+        skipped += 1
+        continue
+
+    # Extract a title (truncated to 300 chars)
+    raw_title = soup.title.string if (soup.title and soup.title.string) else ""
+    title_str = raw_title[:300]
+
+    # Try to find <main> to avoid repeated headers/footers
+    main_content = soup.find("main", class_="container cdc-main")
+    if not main_content:
+        # Fallback to entire page if <main> is missing
+        main_content = soup
+
+    # Remove script/style tags from main content
+    for tag in main_content(["script", "style"]):
+        tag.decompose()
+
+    # Extract text
+    text_str = main_content.get_text(separator=" ", strip=True)
+    if not text_str.strip():
+        skipped += 1
+        continue
+
+    # Deduplicate docs based on normalized path
+    new_len = len(raw_path)
+    if norm in dedup_dict:
+        old_raw, old_len = dedup_dict[norm]
+        if new_len < old_len:
+            # If the new path is shorter, replace the older doc in the index
+            writer.delete_by_term("path", old_raw)
+            writer.update_document(path=raw_path, title=title_str, content=text_str)
+            dedup_dict[norm] = (raw_path, new_len)
+        else:
+            # Otherwise skip this doc
+            skipped += 1
+            continue
+    else:
+        # First time we see this normalized path
+        writer.update_document(path=raw_path, title=title_str, content=text_str)
+        dedup_dict[norm] = (raw_path, new_len)
+
+    processed += 1
+    progress_bar.update(1)
+
+writer.commit()
+db.close()
+
+print(
+    f"Indexing complete. Processed {processed} documents; skipped {skipped} documents."
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,7 @@ libzim
 plyvel
 flask
 waitress
+whoosh-reloaded
+beautifulsoup4
+lxml
+tdqm

--- a/serve.py
+++ b/serve.py
@@ -1,11 +1,16 @@
 from urllib import parse
-from flask import Flask, Response, redirect, render_template
+from flask import Flask, Response, redirect, render_template, request
 from waitress import serve
 import plyvel
 import re
 
+# Whoosh-reloaded imports for search functionality
+from whoosh.index import open_dir
+from whoosh.qparser import QueryParser, OrGroup, MultifieldParser
+from whoosh import sorting, scoring
+
 # this is the path of the LevelDB database we converted from .zim using zim_converter.py
-db = plyvel.DB('./cdc_database')
+db = plyvel.DB("./cdc_database")
 
 # the LevelDB database has 2 keyspaces, one for the content, and one for its type
 # please check zim_converter.py script comments for more info
@@ -18,167 +23,323 @@ app = Flask(__name__)
 hostName = "127.0.0.1"
 serverPort = 9090
 
-# we will use the following regex to add a disclaimer after the body tag 
-body_tag_regex = re.compile(r'(<body\b[^>]*>)', re.IGNORECASE)
+# Where the whoosh search index lives
+INDEX_DIR = "search_index"
+
+# we will use the following regex to add a disclaimer after the body tag
+body_tag_regex = re.compile(r"(<body\b[^>]*>)", re.IGNORECASE)
 body_end_tag_regex = re.compile(r"</body>", re.IGNORECASE)
 # CDC logo replace
 logo_pattern = r"cdc-logo|logo-notext|logo2|favicon|apple-touch-icon|safari-pinnned-tab|us_flag_small"
 svg_pattern = re.compile(r"<svg[^>]*>.*?</svg>", re.DOTALL)
-
 
 # Fix floating navigation
 nav_pattern = r'(<nav\b[^>]*\bclass="[^"]*\bnavbar navbar-expand-lg fixed-top navbar-on-scroll hide\b[^"]*"[^>]*)>'
 nav_replace = r'\1 style = "top: 100px;">'
 
 # this disclaimer will be at the top of every page.
-DISCLAIMER_HTML = '''
+DISCLAIMER_HTML = """
 <div style="position: sticky; top: 0; background: #f8f9fa; height: 100px; padding: 5px; border-bottom: 2px solid #ddd; z-index: 1000; display: flex; align-items:center;justify-content: space-between; font-size: 0.9em; overflow:hidden;">
   <div style="flex: 1; overflow-y: auto; padding-right: 5px; max-height:100px;">
     <p style = "margin: 0; font-size: color: #555;">Original site: $NAME<br> RestoredCDC.org is an independent project and is not affiliated with, endorsed by, or associated with the Centers for Disease Control and Prevention (CDC) or any government entity. The CDC provides information free of charge at <a href="http://www.cdc.gov">CDC.gov</a>. Note the following: 1) Due to archival on January 6, 2025, no information on recent outbreaks is available. 2) Videos have not been restored. 3) Go to <a href="https://data.restoredcdc.org">data.restoredcdc.org</a>(folder organization on-going) to access restored data. 4) Use of this site implies acceptance of this disclaimer.</p>
   </div>
   <div style="display: flex; flex-direction: column; gap: 5px; flex-shrink: 0;text-align: center; font-size: 0.8em">
     <a href="https://aboutus.restoredcdc.org/mission" target="_blank" style="padding: 8px 15px; font-weight: bold; background: #2A1E5C; color: white; text-decoration: none; border-radius: 5px;">About RestoredCDC.org</a>
-    <a href="https://github.com/RestoredCDC/CDC_zim_mirror/issues/new/choose" style="padding: 8px 15px; font-weight: bold; background: #2A1E5C; color: white; text-decoration:none; border-radius: 5px" target="_blank">Report a Problem</a>
+    <a href="https://bugs.restoredcdc.org" style="padding: 8px 15px; font-weight: bold; background: #2A1E5C; color: white; text-decoration:none; border-radius: 5px" target="_blank">Report a Problem</a>
   </div>
 </div>
-'''
+"""
 
-desktop_search_pattern = re.compile(r'<form id="cdc-desktop-search-form".*?</form>', re.DOTALL)
-
-desktop_search_replace = '''
-<form id="cdc-desktop-search-form" class="cdc-header-search-form" role="search" onsubmit="return false;">
-    <input class="form-control" type="search" name="q" data-search-input aria-label="Search" placeholder="Search (Disabled)" disabled title="Search is currently disabled.">
-    <button type="submit" disabled title="Search is disabled"><span class="cdc-fa-magnifying-glass"></span></button>
-    <button type="button" title="Search is disabled"><span class="cdc-icon-close"></span></button>
+# Patterns to replace the disabled search forms in the legacy code with functional ones
+desktop_search_pattern = re.compile(
+    r'<form id="cdc-desktop-search-form".*?</form>', re.DOTALL
+)
+desktop_search_replace = """
+<form id="cdc-desktop-search-form" class="cdc-header-search-form" role="search" action="/search" method="get">
+    <input class="form-control" type="search" name="q" data-search-input aria-label="Search" placeholder="Search RestoredCDC">
+    <button type="submit" title="Search"><span class="cdc-fa-magnifying-glass"></span></button>
+    <button type="button" title="Clear Search" onclick="document.querySelector('#cdc-desktop-search-form input[name=q]').value=''">
+        <span class="cdc-icon-close"></span>
+    </button>
 </form>
+"""
 
-'''
-
-sticky_search_pattern = re.compile(r'<form id="sticky-cdc-desktop-search-form".*?</form>', re.DOTALL)
-
-sticky_search_replace = '''
-<form id="sticky-cdc-desktop-search-form" class="cdc-header-search-form" role="search" onsubmit="return false;">
-    <input class="form-control" type="search" name="q" data-search-input aria-label="Search" placeholder="Search (Disabled)" disabled title="Search is currently disabled.">
-    <button type="submit" disabled title="Search is disabled"><span class="cdc-fa-magnifying-glass"></span></button>
-    <button type="button" title="Search is disabled"><span class="cdc-icon-close"></span></button>
+sticky_search_pattern = re.compile(
+    r'<form id="sticky-cdc-desktop-search-form".*?</form>', re.DOTALL
+)
+sticky_search_replace = """
+<form id="sticky-cdc-desktop-search-form" class="cdc-header-search-form" role="search" action="/search" method="get">
+    <input class="form-control" type="search" name="q" data-search-input aria-label="Search" placeholder="Search RestoredCDC">
+    <button type="submit" title="Search"><span class="cdc-fa-magnifying-glass"></span></button>
+    <button type="button" title="Clear Search" onclick="document.querySelector('#sticky-cdc-desktop-search-form input[name=q]').value=''">
+        <span class="cdc-icon-close"></span>
+    </button>
 </form>
+"""
 
-'''
-
-
-mobile_search_pattern = re.compile(r'<form id="cdc-mobile-search-form".*?</form>',re.DOTALL)
-
-mobile_search_replace = '''
-<form id="cdc-mobile-search-form" class="cdc-header-search-form" role="search" onsubmit="return false;">
-    <input class="form-control" type="search" name="q" data-search-input aria-label="Search" placeholder="Search (Disabled)" disabled title="Search is currently disabled.">
-    <button type="submit" disabled title="Search is disabled"><span class="cdc-fa-magnifying-glass"></span></button>
-    <button type="button" title="Search is disabled"><span class="cdc-icon-close"></span></button>
+mobile_search_pattern = re.compile(
+    r'<form id="cdc-mobile-search-form".*?</form>', re.DOTALL
+)
+mobile_search_replace = """
+<form id="cdc-mobile-search-form" class="cdc-header-search-form" role="search" action="/search" method="get">
+    <input class="form-control" type="search" name="q" data-search-input aria-label="Search" placeholder="Search RestoredCDC">
+    <button type="submit" title="Search"><span class="cdc-fa-magnifying-glass"></span></button>
+    <button type="button" title="Clear Search" onclick="document.querySelector('#cdc-mobile-search-form input[name=q]').value=''">
+        <span class="cdc-icon-close"></span>
+    </button>
 </form>
+"""
 
-'''
-
-search_override = '''
+# Short script to ensure search forms point to /search if the page's JS tries to override it.
+search_fix_script = """
 <script>
 document.addEventListener("DOMContentLoaded", function () {
-    setTimeout(function () {
-        if (window.CDC_CONFIG) {
-            // Override search URL globally
-            window.CDC_CONFIG.search_url = "https://www.google.com/search";
-        }
-
-        // Fix all search forms
-        var searchForms = [
-            document.querySelector('#cdc-desktop-search-form'),
-            document.querySelector('#cdc-mobile-search-form'),
-            document.querySelector('#sticky-cdc-desktop-search-form')
-        ];
-
-        searchForms.forEach(form => {
-            if (form) {
-                // Force the correct search action
-                form.action = "https://www.google.com/search";
-
-                // Ensure the search input field uses "q" for Google
-                if (form.querySelector('[type="search"]')) {
-                    form.querySelector('[type="search"]').name = "q";
-                }
-
-                console.log("Fixed search form action for:", form.id);
-            }
-        });
-    }, 1000); // Wait longer to ensure CDC scripts load first
+    var searchForms = document.querySelectorAll('form.cdc-header-search-form');
+    searchForms.forEach(function(form) {
+        form.action = "/search";
+    });
 });
 </script>
-
-'''
-
-# we need the root of the site to be /www.cdc.gov/ so if our domain is
-# www.example.com when someone visits www.example.com we need to redirect
-# them to www.example.com/www.cdc.com/ subfolder. the home route ensures that.
+"""
 
 
 @app.route("/")
 def home():
-  return redirect("/www.cdc.gov/")
+    """
+    we need the root of the site to be /www.cdc.gov/ so if our domain is
+    www.example.com when someone visits www.example.com we need to redirect
+    them to www.example.com/www.cdc.com/ subfolder. the home route ensures that.
+    """
+    return redirect("/www.cdc.gov/")
 
-# Catch-all route
-# from here we will collect the path requested after www.example.com
-# and look for it in the database so if a request for www.example.com/www.cdc.gov/something/image.jpg
-# is requested, here we capture /www.cdc.gov/something/image.jpg part of it, remove the first / character
-# then search for the remaining path in database, get its data and type from the database
-# and serve it back directly.
 
-@app.route('/<path:subpath>')
+@app.route("/<path:subpath>")
 def lookup(subpath):
+    """
+    Catch-all route
+    from here we will collect the path requested after www.example.com
+    and look for it in the database so if a request for www.example.com/www.cdc.gov/something/image.jpg
+    is requested, here we capture /www.cdc.gov/something/image.jpg part of it, remove the first / character
+    then search for the remaining path in database, get its data and type from the database
+    and serve it back directly.
+    """
 
-  try:
-    # capture the path and fix its quoted characters
-    full_path = parse.unquote(subpath)
-    # print(f"Request for: {full_path}")
+    try:
+        # capture the path and fix its quoted characters
+        full_path = parse.unquote(subpath)
+        # print(f"Request for: {full_path}")
 
-    # convert the path to bytes and get the content from the database
-    content = content_db.get(bytes(full_path, "UTF-8"))
-    # convert the path to bytes and get the content type from the database and decode it to a string
-    # (mimetype is always a string)
-    mimetype = mimetype_db.get(bytes(full_path, "UTF-8")).decode("utf-8")
+        # convert the path to bytes and get the content from the database
+        content = content_db.get(bytes(full_path, "UTF-8"))
+        # convert the path to bytes and get the content type from the database and decode it to a string
+        # (mimetype is always a string)
+        mimetype = mimetype_db.get(bytes(full_path, "UTF-8")).decode("utf-8")
 
-    # if the content type is the special value "=redirect=" this path redirected to another
-    # at crawl time. for relative paths to work, we need to just redirect the user to that
-    # target path.
-    if mimetype == "=redirect=":
-      return redirect(f'/{content.decode("utf-8")}')
-    
-    if mimetype.startswith("text/html"):
-      content = content.decode("utf-8")
-      # here we add the disclaimer with a regex if the request is for a html file.
-      content = body_tag_regex.sub(r'\1' + DISCLAIMER_HTML, content, count=1)
-      # and replace the official notice
-      content = content.replace("An official website of the United States government","")
-      content = re.sub(re.escape("$NAME"),subpath, content, count = 1)
-      content = re.sub(logo_pattern,"",content)
-      content = re.sub(svg_pattern,"",content)
-      content = content.replace("Centers for Disease Control and Prevention. CDC twenty four seven. Saving Lives, Protecting People","")
-      content = content.replace('alt="Centers for Disease Control and Prevention"',"")
-      content = content.replace('alt="U.S. flag"',"")
-      content = content.replace('hp2024.js',"")
-      content = content.replace('id="cdc-footer-nav"','id="cdc-footer-nav" style="display:block !important;"')
-      content = re.sub(nav_pattern, nav_replace, content, count=1)
-      content = content.replace('<title>','<title>Restored CDC | ')
-      content = content.replace('href="https://www.cdc.gov', 'href="https://www.restoredcdc.org')
-      content = re.sub(desktop_search_pattern, desktop_search_replace, content)
-      content = re.sub(sticky_search_pattern, sticky_search_replace, content)
-      content = re.sub(mobile_search_pattern, mobile_search_replace, content)
-    #  content = re.sub(body_end_tag_regex, search_override + "\n</body>", content)
-    # if the path was not a redirect, serve the content directly along with its mimetype
-    # the browser will know what to do with it.
-    return Response(content, mimetype=mimetype)
-  except Exception as e:
-    # if anything is wrong, just send a 404
-    # print(f"Error retrieving {full_path}: {e}")
-    # return Response("404 Not Found", status=404, mimetype="text/plain")
-    # return render_template("404.html", error=str(e)), 404 
-    return render_template('404.html'), 404
+        # if the content type is the special value "=redirect=" this path redirected to another
+        # at crawl time. for relative paths to work, we need to just redirect the user to that
+        # target path.
+        if mimetype == "=redirect=":
+            return redirect(f'/{content.decode("utf-8")}')
 
-if __name__ == '__main__':
-  print(f"Starting cdcmirror server process at port {serverPort}")
-  serve(app, host=hostName, port=serverPort)
+        if mimetype.startswith("text/html"):
+            content = content.decode("utf-8")
+            # here we add the disclaimer with a regex if the request is for a html file.
+            content = body_tag_regex.sub(r"\1" + DISCLAIMER_HTML, content, count=1)
+            # and replace the official notice
+            content = content.replace(
+                "An official website of the United States government", ""
+            )
+            content = re.sub(re.escape("$NAME"), subpath, content, count=1)
+            content = re.sub(logo_pattern, "", content)
+            content = re.sub(svg_pattern, "", content)
+            content = content.replace(
+                "Centers for Disease Control and Prevention. CDC twenty four seven. Saving Lives, Protecting People",
+                "",
+            )
+            content = content.replace(
+                'alt="Centers for Disease Control and Prevention"', ""
+            )
+            content = content.replace('alt="U.S. flag"', "")
+            content = content.replace("hp2024.js", "")
+            content = content.replace(
+                'id="cdc-footer-nav"',
+                'id="cdc-footer-nav" style="display:block !important;"',
+            )
+            content = re.sub(nav_pattern, nav_replace, content, count=1)
+            content = content.replace("<title>", "<title>Restored CDC | ")
+            content = content.replace(
+                'href="https://www.cdc.gov', 'href="https://www.restoredcdc.org'
+            )
+            content = re.sub(
+                desktop_search_pattern,
+                desktop_search_replace + search_fix_script,
+                content,
+            )
+            content = re.sub(
+                sticky_search_pattern,
+                sticky_search_replace + search_fix_script,
+                content,
+            )
+            content = re.sub(
+                mobile_search_pattern,
+                mobile_search_replace + search_fix_script,
+                content,
+            )
+
+        #  content = re.sub(body_end_tag_regex, search_override + "\n</body>", content)
+        # if the path was not a redirect, serve the content directly along with its mimetype
+        # the browser will know what to do with it.
+        return Response(content, mimetype=mimetype)
+    except Exception as e:
+        # if anything is wrong, just send a 404
+        # print(f"Error retrieving {full_path}: {e}")
+        # return Response("404 Not Found", status=404, mimetype="text/plain")
+        # return render_template("404.html", error=str(e)), 404
+        return render_template("404.html"), 404
+
+
+def process_snippets(snippet):
+    """
+    Removes duplicated snippet fragments from a Whoosh highlight string,
+    ensures each snippet ends with '...', and adds '...' if it starts mid-sentence.
+    """
+    snips = snippet.replace("\n", "").split("...")
+    seen = set()
+    unique_snips = []
+    for fragment in snips:
+        processed_snip = fragment.strip()
+        if not processed_snip:
+            continue
+        lower_snip = processed_snip.lower()
+        if lower_snip in seen:
+            # Skip any exact duplicates (case-insensitive).
+            continue
+        seen.add(lower_snip)
+        # If snippet starts in the middle of a sentence, prepend '...'.
+        if processed_snip[0].islower() and not processed_snip.startswith("..."):
+            processed_snip = "..." + processed_snip
+        # Ensure snippet ends with '...'.
+        if not processed_snip.endswith("..."):
+            processed_snip += "..."
+        unique_snips.append(processed_snip)
+    return "\n".join(unique_snips)
+
+
+def suggest_spelling(ix, query, fieldname="content"):
+    """
+    Suggests a corrected query if Whoosh finds a likely alternative
+    (e.g., user gets 0 results for a misspelled term).
+    """
+    with ix.searcher(weighting=scoring.BM25F()) as searcher:
+        # parser = QueryParser(fieldname, ix.schema, group=OrGroup.factory(0.8))
+        parser = MultifieldParser(["title", "content"], schema=ix.schema)
+        original_q = parser.parse(query)
+        corrected = searcher.correct_query(original_q, query)
+        if corrected.query != original_q:
+            return corrected.string
+    return None
+
+
+@app.route("/search")
+def search_route():
+    """
+    Primary search endpoint. Uses Whoosh-reloaded to parse the user query,
+    apply optional sorting, truncate overly long queries,
+    and return relevant results or 'did you mean' suggestions.
+    """
+    user_query = request.args.get("q", "").strip() if "q" in request.args else ""
+
+    # Limit queries to prevent performance issues or crashes on extremely long inputs.
+    MAX_QUERY_LENGTH = 200
+    if len(user_query) > MAX_QUERY_LENGTH:
+        trimmed_query = user_query[:MAX_QUERY_LENGTH]
+        notice = f"Your search query was too long and has been shortened to {MAX_QUERY_LENGTH} characters."
+    else:
+        trimmed_query = user_query
+        notice = None
+
+    page_str = request.args.get("page", "1")
+    sortby = request.args.get("sortby", "score")
+    try:
+        page_num = max(1, int(page_str))
+    except ValueError:
+        page_num = 1
+
+    results_list = []
+    total_hits = 0
+    did_you_mean = None
+
+    if trimmed_query:
+        ix = open_dir(INDEX_DIR)
+        with ix.searcher(weighting=scoring.BM25F()) as searcher:
+            parser = QueryParser("content", ix.schema, group=OrGroup.factory(0.8))
+            try:
+                qobj = parser.parse(trimmed_query)
+            except Exception as e:
+                return f"Error parsing query: {e}", 400
+
+            # Determine sorting if specified (either by score or by title).
+            facet = None
+            if sortby == "title":
+                facet = sorting.FieldFacet("title", reverse=False)
+
+            page_len = 15
+            try:
+                page_obj = searcher.search_page(
+                    qobj, page_num, pagelen=page_len, sortedby=facet, terms=True
+                )
+            except Exception as e:
+                return f"Error retrieving page: {e}", 500
+
+            # Attempt "did you mean" if no hits on first page.
+            if page_num == 1 and len(page_obj) == 0:
+                did_you_mean = suggest_spelling(ix, trimmed_query)
+
+            # Configure highlight snippet length.
+            if page_obj.results:
+                page_obj.results.fragmenter.maxchars = 250
+                page_obj.results.fragmenter.surround = 40
+
+            total_hits = page_obj.total
+
+            for hit in page_obj:
+                snippet = hit.highlights("content", top=3)
+                cleaned_snippet = process_snippets(snippet)
+                results_list.append(
+                    {
+                        "title": hit.get("title", "No Title"),
+                        "path": hit["path"],
+                        "snippet": cleaned_snippet,
+                    }
+                )
+
+    # Insert disclaimer text after we finalize the query.
+    final_disclaimer = DISCLAIMER_HTML.replace("$NAME", "www.cdc.gov/")
+
+    return render_template(
+        "search_results.html",
+        query=trimmed_query,
+        results=results_list,
+        total=total_hits,
+        page=page_num,
+        did_you_mean=did_you_mean,
+        sortby=sortby,
+        disclaimer=final_disclaimer,
+        notice=notice,
+    )
+
+
+@app.route("/search.cdc.gov/search/")
+def cdc_search_redirect():
+    """
+    Catches legacy references to search.cdc.gov and redirects queries
+    back to our local /search route.
+    This is a bit hacky, but prevents needing to change the <path:subpath> route redirect.
+    """
+    q = request.args.get("q", "")
+    return redirect(f"/search?q={q}")
+
+
+if __name__ == "__main__":
+    print(f"Starting cdcmirror server process at port {serverPort}")
+    serve(app, host=hostName, port=serverPort)

--- a/serve.py
+++ b/serve.py
@@ -276,7 +276,8 @@ def search_route():
             try:
                 qobj = parser.parse(trimmed_query)
             except Exception as e:
-                return f"Error parsing query: {e}", 400
+                # app.logger.error(f"Error parsing query: {e}")  # If we setup logging later
+                return "An error occurred while processing your request.", 500
 
             # Determine sorting if specified (either by score or by title).
             facet = None
@@ -289,7 +290,8 @@ def search_route():
                     qobj, page_num, pagelen=page_len, sortedby=facet, terms=True
                 )
             except Exception as e:
-                return f"Error retrieving page: {e}", 500
+                # app.logger.error(f"Error retrieving page: {e}")  # If we setup logging later
+                return "An internal error has occurred.", 500
 
             # Attempt "did you mean" if no hits on first page.
             if page_num == 1 and len(page_obj) == 0:

--- a/serve.py
+++ b/serve.py
@@ -45,7 +45,7 @@ DISCLAIMER_HTML = """
   </div>
   <div style="display: flex; flex-direction: column; gap: 5px; flex-shrink: 0;text-align: center; font-size: 0.8em">
     <a href="https://aboutus.restoredcdc.org/mission" target="_blank" style="padding: 8px 15px; font-weight: bold; background: #2A1E5C; color: white; text-decoration: none; border-radius: 5px;">About RestoredCDC.org</a>
-    <a href="https://bugs.restoredcdc.org" style="padding: 8px 15px; font-weight: bold; background: #2A1E5C; color: white; text-decoration:none; border-radius: 5px" target="_blank">Report a Problem</a>
+    <a href="https://github.com/RestoredCDC/CDC_zim_mirror/issues" style="padding: 8px 15px; font-weight: bold; background: #2A1E5C; color: white; text-decoration:none; border-radius: 5px" target="_blank">Report a Problem</a>
   </div>
 </div>
 """

--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -1,0 +1,183 @@
+<!--
+  search_results.html
+  -------------------
+  Renders search results from our Whoosh-based search.
+
+  Variables passed from Flask:
+    - query: the user's (potentially trimmed) search query
+    - results: a list of result dictionaries with {title, path, snippet}
+    - total: total number of hits
+    - page: current page number
+    - did_you_mean: spelling suggestion if available
+    - sortby: "score" or "title" (the sorting mechanism)
+    - disclaimer: HTML snippet to display at the top of the page
+    - notice: optional message if the query was truncated
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Search Results for "{{ query }}" | RestoredCDC</title>
+  <style>
+    /* Basic styling for the search results page */
+    body {
+      font-family: sans-serif;
+      margin: 0;
+      padding: 0;
+    }
+    header {
+      background: #005ea2;
+      color: #fff;
+      padding: 0.75rem 0;
+    }
+    .header-content {
+      max-width: 80%;
+      width: 95%;
+      margin: 0 auto;
+      padding: 0.75rem 1rem;
+    }
+    main {
+      font-size: 18px;
+      max-width: 80%;
+      width: 95%;
+      margin: 0 auto;
+      padding: 1rem;
+    }
+    h1 {
+      margin-top: 0;
+    }
+    .header-disclaimer { 
+      margin-bottom: 0; 
+    }
+    .nav-buttons {
+      margin: 1rem 0;
+    }
+    .nav-buttons a {
+      display: inline-block;
+      margin-right: 1em;
+      padding: 0.5em 1em;
+      background-color: #2A1E5C;
+      color: white;
+      text-decoration: none;
+      border-radius: 5px;
+    }
+    .search-form input[type="text"] {
+      width: 300px;
+    }
+    .pager a {
+      margin-right: 1em;
+    }
+    .result-item {
+      margin-bottom: 1em;
+    }
+    .result-item a {
+      font-weight: bold;
+      color: #0066cc;
+      text-decoration: none;
+    }
+    .result-snippet {
+      font-size: 0.9em;
+      color: #444;
+      line-height: 1.4;
+    }
+    .result-snippet br {
+      display: block;
+      content: "";
+      margin-top: 6px;
+    }
+  </style>
+</head>
+<body>
+
+<!-- Insert the disclaimer at the top -->
+<div class="header-disclaimer">
+  {{ disclaimer|safe }}
+</div>
+
+<header>
+  <div class="header-content">
+    <h1>RestoredCDC.org Search</h1>
+    <div class="nav-buttons">
+      <!-- Link back to the main site -->
+      <a href="/www.cdc.gov/">&#8592; Back to RestoredCDC.org</a>
+      <!-- Forward user to search restoredcdc.org using Google search -->
+      <a href="https://www.google.com/search?q=site:restoredcdc.org+{{ query|urlencode }}" target="_blank">Search with Google</a>
+      <!-- Forward users search to cdc.gov -->
+      <a href="https://search.cdc.gov/search/?query={{ query|urlencode }}" target="_blank">
+        Search on CDC.gov
+      </a>
+    </div>
+  </div>
+</header>
+
+<main>
+  <!-- This form allows the user to refine or modify their query. -->
+  <form class="search-form" action="/search" method="get">
+    <input type="text" name="q" value="{{ query }}" placeholder="Search RestoredCDC.org" maxlength="200">
+    <label for="sortby">Sort by:</label>
+    <select id="sortby" name="sortby">
+      <option value="score" {% if sortby == "score" %}selected{% endif %}>Relevance</option>
+      <option value="title" {% if sortby == "title" %}selected{% endif %}>Title</option>
+    </select>
+    <input type="submit" value="Search">
+  </form>
+
+  <!-- 'Did you mean' suggestion if we have zero hits or a likely correction -->
+  {% if did_you_mean %}
+    <div style="margin:1em 0;padding:0.5em;background:#fffbcc;border:1px solid #ddd;">
+      Did you mean:
+      <a href="?q={{ did_you_mean|urlencode }}&page=1&sortby={{ sortby|urlencode }}">
+        <strong>{{ did_you_mean }}</strong>
+      </a>
+      ?
+    </div>
+  {% endif %}
+
+  <!-- Optional notice if the query was truncated due to length -->
+  {% if notice %}
+    <div style="color: orange; font-weight: bold; margin-top: 10px;">
+      {{ notice }}
+    </div>
+  {% endif %}
+
+  <!-- Display results if present -->
+  {% if results %}
+    <div>
+      <p>Showing up to {{ results|length }} of {{ total }} results for "<strong>{{ query }}</strong>".</p>
+    </div>
+    <hr>
+
+    <ul style="list-style:none;padding-left:0;">
+      {% for result in results %}
+        <li class="result-item">
+          <a href="/{{ result.path }}">{{ result.title }} | RestoredCDC.org</a><br>
+          <span class="result-snippet">{{ result.snippet | replace("\n", "<br>") | safe }}</span>
+        </li>
+      {% endfor %}
+    </ul>
+
+    <!-- Simple pagination controls (Prev / Next) -->
+    {% set last_page = (total // 15) + (1 if (total % 15) else 0) %}
+    {% if last_page > 1 %}
+      <div class="pager">
+        {% if page > 1 %}
+          <a href="?q={{ query|urlencode }}&page={{ page|int - 1 }}&sortby={{ sortby|urlencode }}">
+            ← Prev
+          </a>
+        {% endif %}
+        <span>Page {{ page }} of {{ last_page }}</span>
+        {% if page < last_page %}
+          <a href="?q={{ query|urlencode }}&page={{ page|int + 1 }}&sortby={{ sortby|urlencode }}">
+            Next →
+          </a>
+        {% endif %}
+      </div>
+    {% endif %}
+  {% else %}
+    <p>No results found.</p>
+  {% endif %}
+</main>
+</body>
+</html>
+


### PR DESCRIPTION


This PR restores the search functionality for RestoredCDC by implementing a Whoosh-based search index.  

**Main Changes:**  
- Added `build_search_index.py`, which builds a Whoosh search index from the LevelDB content.  
- Updated `serve.py` to handle search queries, return ranked results using BM25F, and provide basic query corrections.  
- Updated the search results template (`search_results.html`).  
- Fixed search input handling for mobile and desktop.  
- Added dependencies (`whoosh-reloaded`, `beautifulsoup4`, `lxml`, `tqdm`) to `requirements.txt`.  
- Improved content extraction in `serve.py`:
  - Strips out headers/footers when possible.
  - Deduplicates content based on normalized paths.  
- Replaced the disabled search form placeholders with working search boxes.  

Let me know if anything needs adjustments.